### PR TITLE
change model structure***

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3816,6 +3816,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "axios": "^0.21.1",
     "clsx": "^1.1.1",
     "date-fns": "^2.16.1",
     "node-sass": "4.14.1",

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -35,7 +35,7 @@ export function useOpenDispatch() {
 
 /* project context */
 export type UserObj = {
-	userID: number;
+	userID : number;
 	userName: string;
 	userIcon: string;
 }
@@ -47,69 +47,103 @@ type Attribute = {
 
 export type TaskObj = {
 	taskID: number;
-	listID: number;
-	index: number;
+	attribute: Array<Attribute>;
 	createAt: Date;
 	modifiedAt: Date;
-	attribute: Array<Attribute>
 }
 
 type ListObj = {
 	listID: number;
-	projectID: number;
-	index: number;
-	createAt: Date;
-	modifiedAt: Date;
+	// index는 배열 순서대로 다시 집어넣기
 	name: string;
-	tasks: Array<TaskObj>;
 }
 
 export type ProjectObj = {
-	projectID: number;
-	createAt: Date;
-	modifiedAt: Date;
-	isPrivate: boolean;
-	bookMark: boolean;
-	bgColor: string;
-	name: string;
-	users : Array<UserObj>;
-	List: Array<ListObj>;
+	[projectID : number] : {
+		isPrivate: boolean;
+		bookMark: boolean;
+		bgColor: string;
+		name: string;
+	}
 }
 
-export const ProjectDataContext = createContext<Array<ProjectObj> | undefined>(undefined);
-export const ProjectDispatchContext = createContext<Dispatch<Array<ProjectObj>>>(() => {});
+export type ProjectTeamObj = {
+	[projectID : number] : Array<UserObj>;
+}
+
+type ProjectListObj = {
+	[projectID : number] : Array<ListObj>;
+}
+
+export type ProjectTaskObj = {
+	[listID : number] : Array<TaskObj>;
+}
+
+const ProjectDataContext = createContext<ProjectObj | undefined>(undefined);
+const ProjectDispatchContext = createContext<Dispatch<ProjectObj>>(() => {});
+const TeamContext = createContext<ProjectTeamObj | undefined>(undefined);
+const TeamDispatchContext = createContext<Dispatch<ProjectTeamObj>>(() => {});
+const ListContext = createContext<ProjectListObj | undefined>(undefined);
+const ListDispatchContext = createContext<Dispatch<ProjectListObj>>(() => {});
+const TaskContext = createContext<ProjectTaskObj | undefined>(undefined);
+const TaskDispatchContext = createContext<Dispatch<ProjectTaskObj>>(() => {});
 
 export const ProjectContextProvider = ({ children } : childrenObj) => {
-	const [project, setProject] = useState<Array<ProjectObj>>([{
-		projectID: 1,
-		createAt: new Date('2021/01/02'),
-		modifiedAt: new Date('2021/01/02'),
-		isPrivate: false,
-		bookMark: true,
-		bgColor: 'pink',
-		name: 'KOS',
-		users: [{
-			userID: 1,
-			userName: 'heeeun',
-			userIcon: 'child'
-		}, {
-			userID: 2,
-			userName: 'taejin',
-			userIcon: 'beach'
-		}],
-		List: [{
-			listID: 1,
-			projectID: 1,
-			index: 0,
-			createAt: new Date('2021/01/02'),
-			modifiedAt: new Date('2021/01/02'),
-			name: 'ToDo',
-			tasks: [{
-				taskID: 1,
+	const [project, setProject] = useState<ProjectObj>({
+		1: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'pink',
+			name: 'KOS'
+		},
+		2: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'green',
+			name: 'NERA'
+		},
+		3: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'purple',
+			name: 'HHsadfasdfasdfasdfsdafsadf'
+		}
+	});
+
+	const [team, setTeam] = useState<ProjectTeamObj>({
+		1: [
+			{
+				userID: 1,
+				userIcon: 'pet',
+				userName: 'heeeun'
+			},
+			{
+				userID: 2,
+				userIcon: 'apple',
+				userName: 'taejin'
+			}
+		]
+	});
+
+	const [list, setList] = useState<ProjectListObj>({
+		1: [
+			{
 				listID: 1,
-				index: 0,
-				createAt: new Date('2021/01/02'),
-				modifiedAt: new Date('2021/01/02'),
+				name: '할 일'
+			},
+			{
+				listID: 2,
+				name: '끝난 일'
+			}
+		]
+	});
+
+	const [task, setTask] = useState<ProjectTaskObj>({
+		1: [
+			{
+				taskID: 1,
+				createAt: new Date(),
+				modifiedAt: new Date(),
 				attribute: [{
 					key: 'text-field',
 					value: 'hi'
@@ -118,98 +152,26 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 					key: 'tags',
 					value: ['우희은(hinge7)', '김정현(powergee)']
 				}]
-			}]
-		}]
-	}, {
-		projectID: 2,
-		createAt: new Date('2021/01/02'),
-		modifiedAt: new Date('2021/01/02'),
-		isPrivate: true,
-		bookMark: false,
-		bgColor: 'green',
-		name: 'NERAsadddfadasfdafdsasdfasdfasdfasdf',
-		users: [],
-		List: [{
-			listID: 2,
-			projectID: 2,
-			index: 0,
-			createAt: new Date('2021/01/02'),
-			modifiedAt: new Date('2021/01/02'),
-			name: 'ToDo',
-			tasks: [{
-				taskID: 2,
-				listID: 2,
-				index: 0,
-				createAt: new Date('2021/01/02'),
-				modifiedAt: new Date('2021/01/02'),
-				attribute: [{
-					key: 'text-field',
-					value: 'hi'
-				}]
-			}]
-		}]
-	}, {
-		projectID: 3,
-		createAt: new Date('2021/01/07'),
-		modifiedAt: new Date('2021/01/07'),
-		isPrivate: true,
-		bookMark: true,
-		bgColor: 'mint',
-		name: '프로젝트이름이 길면 어떻게 될까요?',
-		users: [],
-		List: [{
-			listID: 3,
-			projectID: 3,
-			index: 0,
-			createAt: new Date('2021/01/07'),
-			modifiedAt: new Date('2021/01/07'),
-			name: 'ToDo',
-			tasks: [{
-				taskID: 3,
-				listID: 3,
-				index: 0,
-				createAt: new Date('2021/01/07'),
-				modifiedAt: new Date('2021/01/07'),
-				attribute: [{
-					key: 'text-field',
-					value: 'hi'
-				}]
-			}]
-		}]
-	}, {
-		projectID: 4,
-		createAt: new Date('2021/01/07'),
-		modifiedAt: new Date('2021/01/07'),
-		isPrivate: false,
-		bookMark: true,
-		bgColor: 'purple',
-		name: '여러 프로젝트 생성',
-		users: [],
-		List: [{
-			listID: 4,
-			projectID: 4,
-			index: 0,
-			createAt: new Date('2021/01/07'),
-			modifiedAt: new Date('2021/01/07'),
-			name: 'ToDo',
-			tasks: [{
-				taskID: 4,
-				listID: 4,
-				index: 0,
-				createAt: new Date('2021/01/07'),
-				modifiedAt: new Date('2021/01/07'),
-				attribute: [{
-					key: 'text-field',
-					value: 'hi'
-				}]
-			}]
-		}]
-	}]);
+			}
+		]
+	});
 
 	return (
 		<ProjectDataContext.Provider value={project}>
 			<ProjectDispatchContext.Provider value={setProject}>
-				{children}
+				<TeamContext.Provider value={team}>
+					<TeamDispatchContext.Provider value={setTeam}>
+						<ListContext.Provider value={list}>
+							<ListDispatchContext.Provider value={setList}>
+								<TaskContext.Provider value={task}>
+									<TaskDispatchContext.Provider value={setTask}>
+										{children}
+									</TaskDispatchContext.Provider>
+								</TaskContext.Provider>
+							</ListDispatchContext.Provider>
+						</ListContext.Provider>
+					</TeamDispatchContext.Provider>
+				</TeamContext.Provider>
 			</ProjectDispatchContext.Provider>
 		</ProjectDataContext.Provider>
 	);
@@ -219,19 +181,42 @@ export function useProjectState() {
 	const context = useContext(ProjectDataContext);
 	return context;
 }
-
 export function useProjectDispatch() {
 	const context = useContext(ProjectDispatchContext);
+	return context;
+}
+export function useTeamState() {
+	const context = useContext(TeamContext);
+	return context;
+}
+export function useTeamDispatch() {
+	const context = useContext(TeamDispatchContext);
+	return context;
+}
+export function useListState() {
+	const context = useContext(ListContext);
+	return context;
+}
+export function useListDispatch() {
+	const context = useContext(ListDispatchContext);
+	return context;
+}
+export function useTaskState() {
+	const context = useContext(TaskContext);
+	return context;
+}
+export function useTaskDispatch() {
+	const context = useContext(TaskDispatchContext);
 	return context;
 }
 
 /* projectID context */
 
-export const PIDContext = createContext<number>(0);
+export const PIDContext = createContext<number>(1);
 export const PIDDispatchContext = createContext<Dispatch<number>>(() => {});
 
 export const PIDContextProvider = ({ children } : childrenObj) => {
-	const [pid, setPID] = useState<number>(0);
+	const [pid, setPID] = useState<number>(1);
 
 	return (
 		<PIDContext.Provider value={pid}>

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -1,6 +1,26 @@
 import React, {
 	useState, createContext, useContext, Dispatch
 } from 'react';
+import axios from 'axios';
+
+/* test user put */
+/*
+export const putUser = async () => {
+	const headers = {
+		'Content-Type': 'application/json;charset=utf-8',
+		'Access-Control-Allow-Origin': '*'
+	};
+
+	axios
+		.get('http://localhost:8080/v1/user-api/users', { headers })
+		.then(({ data }) => {
+			console.log(data);
+		})
+		.catch((e) => {
+			console.error(e);
+		});
+};
+*/
 
 /* open context */
 // create context to use open

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -58,6 +58,7 @@ export type UserObj = {
 	userID : number;
 	userName: string;
 	userIcon: string;
+	gitID: string;
 }
 
 type Attribute = {
@@ -135,12 +136,14 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 			{
 				userID: 1,
 				userIcon: 'pet',
-				userName: 'heeeun'
+				userName: 'heeeun',
+				gitID: 'gmldms784@naver.com'
 			},
 			{
 				userID: 2,
 				userIcon: 'apple',
-				userName: 'taejin'
+				userName: 'taejin',
+				gitID: 'thereisnotruth12@gmail.com'
 			}
 		]
 	});

--- a/frontend/src/components/Shared/SideMenu.tsx
+++ b/frontend/src/components/Shared/SideMenu.tsx
@@ -1,44 +1,72 @@
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useState } from 'react';
 
 import { Grid } from '@material-ui/core';
 
 import LockIcon from '@material-ui/icons/Lock';
 import LockOpenIcon from '@material-ui/icons/LockOpen';
 import StarIcon from '@material-ui/icons/Star';
+import StarBorderIcon from '@material-ui/icons/StarBorder';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
-import { ProjectObj } from '../Model';
+import { ProjectObj, useProjectState, useProjectDispatch } from '../Model';
 import { Button } from '.';
 
 type SideMenuProps = {
 	open : boolean;
 	setOpen : Dispatch<boolean>;
-	project : ProjectObj;
+	pid : number;
 }
 
-const SideMenu = ({ open, setOpen, project } : SideMenuProps) => {
-	const a = 1;
+const SideMenu = ({ open, setOpen, pid } : SideMenuProps) => {
+	const project : ProjectObj | undefined = useProjectState();
+	const setProject : Dispatch<ProjectObj> = useProjectDispatch();
+	const [update, forceUpdate] = useState(true);
+
+	const togglePrivate = () => {
+		if (project === undefined || pid === undefined) {
+			return;
+		}
+		const tmp = project;
+		tmp[pid].isPrivate = !tmp[pid].isPrivate;
+		console.log(`toogle ${pid} to ${!tmp[pid].isPrivate}`);
+		setProject(tmp);
+		forceUpdate(!update);
+	};
+	const toggleMark = () => {
+		if (project === undefined || pid === undefined) {
+			return;
+		}
+		const tmp = project;
+		tmp[pid].bookMark = !tmp[pid].bookMark;
+		console.log(`toogle ${pid} to ${!tmp[pid].bookMark}`);
+		setProject(tmp);
+		forceUpdate(!update);
+	};
+
 	return (
 		<>
-			<Grid className="detail">
-				<Grid className="private">
-					<Button
-						classList={[]}
-						value={project.isPrivate ? <LockIcon /> : <LockOpenIcon />}
-						transparent={true}
-						// onClickFun={() => togglePrivate(project.projectID)}
-					/>
+			{
+				project && pid &&
+				<Grid className="detail">
+					<Grid className="private">
+						<Button
+							classList={[]}
+							value={project[pid].isPrivate ? <LockIcon /> : <LockOpenIcon />}
+							transparent={true}
+							onClickFun={() => togglePrivate()}
+						/>
+					</Grid>
+					<Grid className="book-mark">
+						<Button
+							classList={[]}
+							value={project[pid].bookMark ? <StarIcon /> : <StarBorderIcon />}
+							transparent={true}
+							onClickFun={() => toggleMark()}
+						/>
+					</Grid>
 				</Grid>
-				<Grid className="book-mark">
-					<Button
-						classList={[]}
-						value={project.bookMark ? <StarIcon /> : <></>}
-						transparent={true}
-						// onClickFun={() => setOpen(!open)}
-					/>
-				</Grid>
-			</Grid>
+			}
 			<Grid className="arrow">
 				<Button
 					classList={[]}

--- a/frontend/src/components/Sub/ProjectHead.tsx
+++ b/frontend/src/components/Sub/ProjectHead.tsx
@@ -8,7 +8,9 @@ import BackupIcon from '@material-ui/icons/Backup';
 import {
 	Button, SubMenu, SideMenu, Member
 } from '../Shared';
-import { ProjectObj, useUserState } from '../Model';
+import {
+	ProjectObj, ProjectTeamObj, useUserState, useProjectState, usePIDState, useTeamState
+} from '../Model';
 
 const buttonRef = createRef<HTMLDivElement>();
 const searchInputRef = createRef<HTMLDivElement>();
@@ -16,14 +18,17 @@ const searchInputRef = createRef<HTMLDivElement>();
 type ProjectHeadProps = {
 	sideBarOpen : boolean;
 	handleSideBarOpen : () => void;
-	project : ProjectObj
 }
 
 const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
-	sideBarOpen, handleSideBarOpen, project
+	sideBarOpen, handleSideBarOpen
 }, ref) => {
-	const [open, setOpen] = useState(false);
+	const project : ProjectObj | undefined = useProjectState();
+	const team : ProjectTeamObj | undefined = useTeamState();
+	const pid : number = usePIDState();
 	const userID : number = useUserState();
+
+	const [open, setOpen] = useState(false);
 
 	const searchTask = () => {
 		console.dir(searchInputRef.current);
@@ -42,38 +47,46 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 							ref={buttonRef}
 						/>
 				}
-				<Grid className="info-con">
-					<Grid className="border-con">
-						<Grid className="info">
-							<Grid className="project-name">{project.name}</Grid>
-							<SideMenu
-								open={open}
-								setOpen={setOpen}
-								project={project}
-							/>
+				{
+					project && pid &&
+					<>
+						<Grid className="info-con">
+							<Grid className="border-con">
+								<Grid className="info">
+									<Grid className="project-name">{project[pid].name}</Grid>
+									<SideMenu
+										open={open}
+										setOpen={setOpen}
+										pid={pid}
+									/>
+								</Grid>
+								{ open && <SubMenu /> }
+							</Grid>
 						</Grid>
-						{ open && <SubMenu /> }
-					</Grid>
-				</Grid>
-				<Grid className="member-con">
-					<Grid className="all-member">
 						{
-							project.users.map((user) => Member(user))
+							team &&
+							<Grid className="member-con">
+								<Grid className="all-member">
+									{
+										team[pid].map((member) => Member(member))
+									}
+								</Grid>
+								<Grid className="my-icon">
+									{
+										team[pid].map((member) => {
+											if (member.userID === userID) {
+												return (
+													Member(member)
+												);
+											}
+											return undefined;
+										})
+									}
+								</Grid>
+							</Grid>
 						}
-					</Grid>
-					<Grid className="my-icon">
-						{
-							project.users.map((user) => {
-								if (user.userID === userID) {
-									return (
-										Member(user)
-									);
-								}
-								return undefined;
-							})
-						}
-					</Grid>
-				</Grid>
+					</>
+				}
 			</Grid>
 			<Grid className="sub-head-con">
 				<Grid className="search-con">

--- a/frontend/src/components/Sub/SideProject.tsx
+++ b/frontend/src/components/Sub/SideProject.tsx
@@ -3,31 +3,33 @@ import clsx from 'clsx';
 
 import { Grid } from '@material-ui/core';
 
-import { ProjectObj } from '../Model';
+import { useProjectState, ProjectObj } from '../Model';
 import { SubMenu, SideMenu } from '../Shared';
 
 type SideProjectProps = {
-	project : ProjectObj;
+	pid: number;
 }
 
-const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({
-	project
-}, ref) => {
+const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ pid }, ref) => {
 	const [open, setOpen] = useState(false);
+	const project : ProjectObj | undefined = useProjectState();
 
 	return (
 		<Grid ref={ref} className="side-project">
-			<Grid className="project-info">
-				<Grid className="info">
-					<Grid className={clsx('bg-color', project.bgColor)}> </Grid>
-					<Grid className="project-name"><p>{project.name.length > 14 ? `${project.name.substr(0, 14)}...` : project.name}</p></Grid>
+			{
+				project &&
+				<Grid className="project-info">
+					<Grid className="info">
+						<Grid className={clsx('bg-color', project[pid].bgColor)}> </Grid>
+						<Grid className="project-name"><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
+					</Grid>
+					<SideMenu
+						open={open}
+						setOpen={setOpen}
+						pid={pid}
+					/>
 				</Grid>
-				<SideMenu
-					open={open}
-					setOpen={setOpen}
-					project={project}
-				/>
-			</Grid>
+			}
 			{ open && <SubMenu /> }
 		</Grid>
 	);

--- a/frontend/src/components/View/PageView.tsx
+++ b/frontend/src/components/View/PageView.tsx
@@ -4,7 +4,9 @@ import { Grid } from '@material-ui/core';
 
 import { Button } from '../Shared';
 import { ProjectHead, List } from '../Sub';
-import { ProjectObj } from '../Model';
+import {
+	useProjectState, usePIDState, useTaskState, ProjectObj, ProjectTaskObj
+} from '../Model';
 import { TaskView } from '.';
 
 const taskRef = createRef<HTMLDivElement>();
@@ -12,15 +14,19 @@ const taskRef = createRef<HTMLDivElement>();
 type PageViewProps = {
 	open: boolean;
 	handleSideBarOpen: () => void;
-	project: ProjectObj;
 }
 
 const PageView = forwardRef<HTMLDivElement, PageViewProps>(({
-	open, handleSideBarOpen, project
+	open, handleSideBarOpen
 }, ref) => {
+	/* ============== 프로젝트 관련 데이터 ============== */
+	const project : ProjectObj | undefined = useProjectState();
+	const pid : number = usePIDState();
+	const tasks : ProjectTaskObj | undefined = useTaskState();
+
 	/* ==============테스크 윈도우 열기 위한 임의의 값들============== */
 	const buttonName = '테스크 설정하기';
-	const task = project && project.List[0].tasks[0];
+	const task = tasks && tasks[1][0];
 	const [openTask, setOpenTask] = useState(false);
 
 	const handleTaskWindowOpen = () => {
@@ -33,12 +39,11 @@ const PageView = forwardRef<HTMLDivElement, PageViewProps>(({
 
 	return (
 		<Grid ref={ref} className="page">
-			{!openTask && project &&
+			{!openTask &&
 				<>
 					<ProjectHead
 						sideBarOpen={open}
 						handleSideBarOpen={handleSideBarOpen}
-						project={project}
 					/>
 					<Button
 						classList={['']}

--- a/frontend/src/components/View/SideBarView.tsx
+++ b/frontend/src/components/View/SideBarView.tsx
@@ -39,7 +39,7 @@ const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
 			</header>
 			<Grid className="project-con">
 				{
-					project && Object.keys(project).map((id) => <SideProject pid={Number(id)} />)
+					project && Object.keys(project).map((id) => <SideProject key={id} pid={Number(id)} />)
 				}
 			</Grid>
 			<Grid className="generate-project">

--- a/frontend/src/components/View/SideBarView.tsx
+++ b/frontend/src/components/View/SideBarView.tsx
@@ -6,49 +6,51 @@ import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 
 import { Button } from '../Shared';
 import { SideProject } from '../Sub';
-import { ProjectObj } from '../Model';
+import { useProjectState, ProjectObj } from '../Model';
 
 const buttonRef = createRef<HTMLDivElement>();
-const projectRef = createRef<HTMLDivElement>();
 
 type SideBarViewProps = {
 	type : string;
 	handleSideBarClose : () => void;
-	project : Array<ProjectObj> | undefined;
 }
 
 // View는 Controller의 data 및 function을 사용하여 사용자와 상호작용
 const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
-	type, handleSideBarClose, project
-}, ref) => (
-	<Grid ref={ref} className={clsx('sidebar', type)}>
-		<header className="sidebar-header">
-			<Grid className="sidebar-header-title">
-				<img src="/logo192.png" alt="logo" />
-				<h1>KOS</h1>
+	type, handleSideBarClose
+}, ref) => {
+	const project : ProjectObj | undefined = useProjectState();
+
+	return (
+		<Grid ref={ref} className={clsx('sidebar', type)}>
+			<header className="sidebar-header">
+				<Grid className="sidebar-header-title">
+					<img src="/logo192.png" alt="logo" />
+					<h1>KOS</h1>
+				</Grid>
+				<Button
+					classList={['sidebar-btn']}
+					value={<ArrowBackIosIcon onClick={handleSideBarClose} />}
+					tooltip="Close Sidebar"
+					ttside="right"
+					transparent={true}
+					ref={buttonRef}
+				/>
+			</header>
+			<Grid className="project-con">
+				{
+					project && Object.keys(project).map((id) => <SideProject pid={Number(id)} />)
+				}
 			</Grid>
-			<Button
-				classList={['sidebar-btn']}
-				value={<ArrowBackIosIcon onClick={handleSideBarClose} />}
-				tooltip="Close Sidebar"
-				ttside="right"
-				transparent={true}
-				ref={buttonRef}
-			/>
-		</header>
-		<Grid className="project-con">
-			{
-				project && project.map((p) => <SideProject key={p.projectID} ref={projectRef} project={p} />)
-			}
+			<Grid className="generate-project">
+				<Button
+					classList={[]}
+					value="+ 새로운 프로젝트 만들기"
+					transparent={true}
+				/>
+			</Grid>
 		</Grid>
-		<Grid className="generate-project">
-			<Button
-				classList={[]}
-				value="+ 새로운 프로젝트 만들기"
-				transparent={true}
-			/>
-		</Grid>
-	</Grid>
-));
+	);
+});
 
 export default SideBarView;

--- a/frontend/src/components/ViewModel.tsx
+++ b/frontend/src/components/ViewModel.tsx
@@ -1,6 +1,6 @@
 import React, { createRef, Dispatch } from 'react';
 import {
-	useOpenState, useOpenDispatch, useProjectState, useProjectDispatch, usePIDState, usePIDDispatch, ProjectObj
+	useOpenState, useOpenDispatch
 } from './Model';
 import { SideBarView, PageView } from './View';
 
@@ -11,10 +11,6 @@ const pageRef = createRef<HTMLDivElement>();
 const ViewModel = () => {
 	const open : boolean = useOpenState();
 	const setOpen : Dispatch<boolean> = useOpenDispatch();
-	const project : Array<ProjectObj> | undefined = useProjectState();
-	const setProject : Dispatch<Array<ProjectObj>> = useProjectDispatch();
-	const pid : number = usePIDState();
-	const setPID : Dispatch<number> = usePIDDispatch();
 
 	const handleSideBarOpen = () => {
 		setOpen(true);
@@ -30,24 +26,18 @@ const ViewModel = () => {
 				open ? <SideBarView
 					type="visible"
 					handleSideBarClose={handleSideBarClose}
-					project={project}
 					ref={sidebarRef}
 				/> : <SideBarView
 					type="unvisible"
 					handleSideBarClose={handleSideBarClose}
-					project={project}
 					ref={sidebarRef}
 				/>
 			}
-			{
-				project &&
-				<PageView
-					handleSideBarOpen={handleSideBarOpen}
-					open={open}
-					project={project[pid]}
-					ref={pageRef}
-				/>
-			}
+			<PageView
+				handleSideBarOpen={handleSideBarOpen}
+				open={open}
+				ref={pageRef}
+			/>
 		</>
 	);
 };

--- a/frontend/src/components/ViewModel.tsx
+++ b/frontend/src/components/ViewModel.tsx
@@ -1,6 +1,6 @@
 import React, { createRef, Dispatch } from 'react';
 import {
-	useOpenState, useOpenDispatch //, putUser
+	useOpenState, useOpenDispatch // , putUser
 } from './Model';
 import { SideBarView, PageView } from './View';
 

--- a/frontend/src/components/ViewModel.tsx
+++ b/frontend/src/components/ViewModel.tsx
@@ -1,6 +1,6 @@
 import React, { createRef, Dispatch } from 'react';
 import {
-	useOpenState, useOpenDispatch
+	useOpenState, useOpenDispatch //, putUser
 } from './Model';
 import { SideBarView, PageView } from './View';
 
@@ -19,6 +19,8 @@ const ViewModel = () => {
 	const handleSideBarClose = () => {
 		setOpen(false);
 	};
+
+	// putUser();
 
 	return (
 		<>


### PR DESCRIPTION
* model에서의 obj 구조를 array에서 dictionary로 변경하였습니다.
* project와 pid context로 현재 선택된 프로젝트에 쉽게 접근할 수 있습니다.
* list 및 task의 index 속성을 없애고, array의 index 자체로 표현하도록 변경하였습니다.
* project 단위로 useState를 사용하기에는 overhead가 너무 크기 때문에, Team, List, Task 단위의 Model로 구조를 나누어두었습니다.
> Project Provider로 한 번에 제공 가능하지만, 각각을 따로 구독할 수 있어 랜더링에 효과적입니다.
> 참고 : https://velopert.com/3606