### PR TITLE
Frontend

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
 		'react/jsx-boolean-value': 0, // boolean 못넘기게 하는 룰 없애기
 		'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
 		'@typescript-eslint/no-empty-function': 0, // ()=>{} 가능하게 하기
+		'prefer-destructuring': ['warn'],
 	},
 	'settings': {
 		'react': {

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -163,6 +163,62 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 
 	const [task, setTask] = useState<ProjectTaskObj>();
 
+	/*
+	// backend를 안켰을 때를 위해 남겨두는 test data
+	const [project, setProject] = useState<ProjectObj>({
+		1: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'pink',
+			name: 'KOS'
+		},
+		2: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'green',
+			name: 'NERA'
+		},
+		3: {
+			isPrivate: false,
+			bookMark: true,
+			bgColor: 'purple',
+			name: 'HHsadfasdfasdfasdfsdafsadf'
+		}
+	});
+
+	const [team, setTeam] = useState<ProjectTeamObj>(
+		[
+			{
+				userID: 1,
+				userIcon: 'pet',
+				userName: 'heeeun',
+				gitID: 'gmldms784@naver.com'
+			},
+			{
+				userID: 2,
+				userIcon: 'apple',
+				userName: 'taejin',
+				gitID: 'thereisnotruth12@gmail.com'
+			}
+		]
+	);
+
+	const [list, setList] = useState<ProjectListObj>([
+		{
+			listID: 1,
+			name: '할 일',
+			index: 0
+		},
+		{
+			listID: 2,
+			name: '끝난 일',
+			index: 1
+		}
+	]);
+
+	const [task, setTask] = useState<ProjectTaskObj>();
+	*/
+
 	const a = 1;
 	const pid = usePIDState();
 

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -151,6 +151,7 @@ const TaskDispatchContext = createContext<Dispatch<ProjectTaskObj>>(() => {});
 
 export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [update, forceUpdate] = useState(true);
+	/*
 	const [project, setProject] = useState<ProjectObj>({});
 
 	const [team, setTeam] = useState<ProjectTeamObj>([]);
@@ -158,8 +159,7 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [list, setList] = useState<ProjectListObj>([]);
 
 	const [task, setTask] = useState<ProjectTaskObj>({});
-
-	/*
+	*/
 	// backend를 안켰을 때를 위해 남겨두는 test data
 	const [project, setProject] = useState<ProjectObj>({
 		1: {
@@ -185,16 +185,18 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [team, setTeam] = useState<ProjectTeamObj>(
 		[
 			{
-				userID: 1,
-				userIcon: 'pet',
-				userName: 'heeeun',
-				gitID: 'gmldms784@naver.com'
+				ID: 1,
+				Icon: 'pet',
+				Name: 'heeeun',
+				GitID: 'gmldms784@naver.com',
+				AuthLVL: 1
 			},
 			{
-				userID: 2,
-				userIcon: 'apple',
-				userName: 'taejin',
-				gitID: 'thereisnotruth12@gmail.com'
+				ID: 2,
+				Icon: 'apple',
+				Name: 'taejin',
+				GitID: 'thereisnotruth12@gmail.com',
+				AuthLVL: 2
 			}
 		]
 	);
@@ -213,7 +215,6 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	]);
 
 	const [task, setTask] = useState<ProjectTaskObj>();
-	*/
 
 	const a = 1;
 	const pid = usePIDState();

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -143,6 +143,7 @@ const ProjectAddContext = createContext<(name : string, pri : boolean) => void>(
 const ProjectDeleteContext = createContext<(id: number) => void>(() => {});
 const TeamContext = createContext<ProjectTeamObj | undefined>(undefined);
 const TeamDispatchContext = createContext<Dispatch<ProjectTeamObj>>(() => {});
+const UserAuthChangeContext = createContext<(uid: number, auth: number) => void>(() => {});
 const ListContext = createContext<ProjectListObj | undefined>(undefined);
 const ListDispatchContext = createContext<Dispatch<ProjectListObj>>(() => {});
 const TaskContext = createContext<ProjectTaskObj | undefined>(undefined);
@@ -299,6 +300,8 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 			});
 	}, [a, pid]); // 나중에는 a를 대체하여 쿠키/세션 정보가 바뀌면 다시 받아오도록 하기
 
+	/* project api 함수 */
+
 	const changeProject = (id : number, p : ProjectObj) => {
 		if (p === undefined) return;
 
@@ -356,6 +359,23 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 			});
 	};
 
+	/* team api 함수 */
+	const userAuthChange = (uid: number, auth: number) => {
+		// 관리자는 유저로, 유저는 관리자로
+		const resultAuth = auth === 1 ? 2 : 1;
+		axios.post('http://localhost:8080/v1/works-in-api/works-in/setAuth', {
+			'ProjectID': pid.toString(),
+			'UserID': uid.toString(),
+			'AuthLVL': auth.toString()
+		})
+			.then((res) => {
+				console.dir(res);
+			})
+			.catch((err) => {
+				console.dir(err);
+			});
+	};
+
 	return (
 		<ProjectDataContext.Provider value={project}>
 			<ProjectUpdateContext.Provider value={changeProject}>
@@ -363,15 +383,17 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 					<ProjectDeleteContext.Provider value={deleteProject}>
 						<TeamContext.Provider value={team}>
 							<TeamDispatchContext.Provider value={setTeam}>
-								<ListContext.Provider value={list}>
-									<ListDispatchContext.Provider value={setList}>
-										<TaskContext.Provider value={task}>
-											<TaskDispatchContext.Provider value={setTask}>
-												{children}
-											</TaskDispatchContext.Provider>
-										</TaskContext.Provider>
-									</ListDispatchContext.Provider>
-								</ListContext.Provider>
+								<UserAuthChangeContext.Provider value={userAuthChange}>
+									<ListContext.Provider value={list}>
+										<ListDispatchContext.Provider value={setList}>
+											<TaskContext.Provider value={task}>
+												<TaskDispatchContext.Provider value={setTask}>
+													{children}
+												</TaskDispatchContext.Provider>
+											</TaskContext.Provider>
+										</ListDispatchContext.Provider>
+									</ListContext.Provider>
+								</UserAuthChangeContext.Provider>
 							</TeamDispatchContext.Provider>
 						</TeamContext.Provider>
 					</ProjectDeleteContext.Provider>
@@ -403,6 +425,10 @@ export function useTeamState() {
 }
 export function useTeamDispatch() {
 	const context = useContext(TeamDispatchContext);
+	return context;
+}
+export function useUserAuthDispatch() {
+	const context = useContext(UserAuthChangeContext);
 	return context;
 }
 export function useListState() {
@@ -460,7 +486,7 @@ export const UserContextProvider = ({ children } : childrenObj) => {
 		userID: 1,
 		userIcon: 'pet',
 		gitID: 'gmldms784@naver.com',
-		AuthLvL: 3
+		AuthLvL: 2
 	});
 	/*
 	const a = 1;

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -39,11 +39,18 @@ export function useOpenDispatch() {
 }
 
 /* project context */
-export type UserObj = {
+type UserObj = {
 	userID : number;
 	userName: string;
 	userIcon: string;
 	gitID: string;
+}
+export type ProjectUserObj = {
+	userID : number;
+	userName: string;
+	userIcon: string;
+	gitID: string;
+	AuthLvL: number;
 }
 
 type Attribute = {
@@ -86,7 +93,7 @@ export type ProjectObj = {
 
 /* 선택된 project에 대한 team, list, task */
 
-export type ProjectTeamObj = Array<UserObj>;
+export type ProjectTeamObj = Array<ProjectUserObj>;
 
 type ProjectListObj = Array<ListObj>;
 
@@ -151,13 +158,15 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 				userID: 1,
 				userIcon: 'pet',
 				userName: 'heeeun',
-				gitID: 'gmldms784@naver.com'
+				gitID: 'gmldms784@naver.com',
+				AuthLvL: 2
 			},
 			{
 				userID: 2,
 				userIcon: 'apple',
 				userName: 'taejin',
-				gitID: 'thereisnotruth12@gmail.com'
+				gitID: 'thereisnotruth12@gmail.com',
+				AuthLvL: 1
 			}
 		]
 	);
@@ -226,6 +235,7 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const pid = usePIDState();
 
 	useEffect(() => {
+		// pid와 세션 정보가 바뀔 때마다 project 정보 다시 받아오기
 		axios.get('http://localhost:8080/v1/project-api/projects')
 			.then(async (res) => {
 				console.log(res);
@@ -441,12 +451,27 @@ export function usePIDDispatch() {
 
 /* user context */
 
-export const userContext = createContext<number>(1);
-const userDispatchContext = createContext<Dispatch<number>>(() => {});
+export const userContext = createContext<ProjectUserObj | undefined>(undefined);
+const userDispatchContext = createContext<Dispatch<ProjectUserObj>>(() => {});
 
 export const UserContextProvider = ({ children } : childrenObj) => {
-	const [id, setUserID] = useState<number>(1);
+	const [id, setUserID] = useState<ProjectUserObj>({
+		userName: 'heeeun',
+		userID: 1,
+		userIcon: 'pet',
+		gitID: 'gmldms784@naver.com',
+		AuthLvL: 3
+	});
+	/*
+	const a = 1;
+	const pid = usePIDState();
 
+	useEffect(() => {
+		// pid와 세션 정보가 바뀔 때마다 user 정보 다시 받아오기
+		// 세션 정보 없으면 로그인 페이지로
+		axios.
+	}, [a, pid]);
+	*/
 	return (
 		<userContext.Provider value={id}>
 			<userDispatchContext.Provider value={setUserID}>

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -46,11 +46,11 @@ type UserObj = {
 	gitID: string;
 }
 export type ProjectUserObj = {
-	userID : number;
-	userName: string;
-	userIcon: string;
-	gitID: string;
-	AuthLvL: number;
+	ID : number;
+	Name : string;
+	Icon : string;
+	GitID : string;
+	AuthLVL : number;
 }
 
 type Attribute = {
@@ -153,24 +153,7 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [update, forceUpdate] = useState(true);
 	const [project, setProject] = useState<ProjectObj>({});
 
-	const [team, setTeam] = useState<ProjectTeamObj>(
-		[
-			{
-				userID: 1,
-				userIcon: 'pet',
-				userName: 'heeeun',
-				gitID: 'gmldms784@naver.com',
-				AuthLvL: 2
-			},
-			{
-				userID: 2,
-				userIcon: 'apple',
-				userName: 'taejin',
-				gitID: 'thereisnotruth12@gmail.com',
-				AuthLvL: 1
-			}
-		]
-	);
+	const [team, setTeam] = useState<ProjectTeamObj>([]);
 
 	const [list, setList] = useState<ProjectListObj>([]);
 
@@ -298,6 +281,17 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 			.catch((e) => {
 				console.dir(e);
 			});
+		/*
+		자꾸 DB 에러남 => 고쳐야함
+		axios.get(`http://localhost:8080/v1/works-in-api/works-in-project/${pid}`)
+			.then((res) => {
+				console.log(res);
+				setTeam(res.data);
+			})
+			.catch((e) => {
+				console.dir(e);
+			});
+		*/
 	}, [a, pid]); // 나중에는 a를 대체하여 쿠키/세션 정보가 바뀌면 다시 받아오도록 하기
 
 	/* project api 함수 */
@@ -482,11 +476,11 @@ const userDispatchContext = createContext<Dispatch<ProjectUserObj>>(() => {});
 
 export const UserContextProvider = ({ children } : childrenObj) => {
 	const [id, setUserID] = useState<ProjectUserObj>({
-		userName: 'heeeun',
-		userID: 1,
-		userIcon: 'pet',
-		gitID: 'gmldms784@naver.com',
-		AuthLvL: 2
+		ID: 1,
+		Name: 'heeeun',
+		Icon: 'pet',
+		GitID: 'gmldms784@naver.com',
+		AuthLVL: 2
 	});
 	/*
 	const a = 1;

--- a/frontend/src/components/Model.tsx
+++ b/frontend/src/components/Model.tsx
@@ -151,7 +151,7 @@ const TaskDispatchContext = createContext<Dispatch<ProjectTaskObj>>(() => {});
 
 export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [update, forceUpdate] = useState(true);
-	/*
+
 	const [project, setProject] = useState<ProjectObj>({});
 
 	const [team, setTeam] = useState<ProjectTeamObj>([]);
@@ -159,7 +159,7 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 	const [list, setList] = useState<ProjectListObj>([]);
 
 	const [task, setTask] = useState<ProjectTaskObj>({});
-	*/
+	/*
 	// backend를 안켰을 때를 위해 남겨두는 test data
 	const [project, setProject] = useState<ProjectObj>({
 		1: {
@@ -213,8 +213,8 @@ export const ProjectContextProvider = ({ children } : childrenObj) => {
 			index: 1
 		}
 	]);
-
 	const [task, setTask] = useState<ProjectTaskObj>();
+	*/
 
 	const a = 1;
 	const pid = usePIDState();

--- a/frontend/src/components/Shared/Member.tsx
+++ b/frontend/src/components/Shared/Member.tsx
@@ -66,15 +66,15 @@ const Member = ({ user } : MemberProps) => {
 	};
 	const userAuthChange = (auth: number) => {
 		// 유저 권한 변경
-		setUserAuth(user.userID, auth);
+		setUserAuth(user.ID, auth);
 	};
 	const returnMenu = () => {
 		let menuString = '관리자 권한 부여';
-		if (user.userID === nowUser?.userID) {
+		if (user.ID === nowUser?.ID) {
 			// 본인 프로필이라면, 메뉴 노출 x
 			return undefined;
 		}
-		if (user.AuthLvL === 1) {
+		if (user.AuthLVL === 1) {
 			// 관리자 권한의 유저라면, '유저 권한으로 되돌리기' 사용
 			menuString = '유저 권한으로 되돌리기';
 		}
@@ -90,7 +90,7 @@ const Member = ({ user } : MemberProps) => {
 				onClose={handleClose}
 				className="menu-popup"
 			>
-				<MenuItem onClick={() => userAuthChange(user.AuthLvL)}>
+				<MenuItem onClick={() => userAuthChange(user.AuthLVL)}>
 					<ListItemIcon>
 						<SupervisedUserCircleIcon />
 					</ListItemIcon>
@@ -108,13 +108,13 @@ const Member = ({ user } : MemberProps) => {
 
 	return (
 		<>
-			<Tooltip placement="bottom" title={user.userName} arrow>
-				<Avatar className={clsx('member', user.userIcon)} onClick={handleClick}>
-					{returnIcon(user.userIcon)}
+			<Tooltip placement="bottom" title={user.Name} arrow>
+				<Avatar className={clsx('member', user.Icon)} onClick={handleClick}>
+					{returnIcon(user.Icon)}
 				</Avatar>
 			</Tooltip>
 			{
-				nowUser && nowUser.AuthLvL === 2 && returnMenu()
+				nowUser && nowUser.AuthLVL === 2 && returnMenu()
 				// 현재 유저가 관리자이면 메뉴 노출
 			}
 		</>

--- a/frontend/src/components/Shared/Member.tsx
+++ b/frontend/src/components/Shared/Member.tsx
@@ -15,7 +15,9 @@ import ChildCareIcon from '@material-ui/icons/ChildCare';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
 import CallMissedOutgoingIcon from '@material-ui/icons/CallMissedOutgoing';
 
-import { useUserState, ProjectUserObj } from '../Model';
+import {
+	useUserState, ProjectUserObj, useUserAuthDispatch
+} from '../Model';
 
 const returnIcon = (text : string) => {
 	let icon = <MoodIcon />;
@@ -54,6 +56,7 @@ type MemberProps = {
 
 const Member = ({ user } : MemberProps) => {
 	const nowUser : ProjectUserObj | undefined = useUserState();
+	const setUserAuth : (uid: number, auth: number) => void = useUserAuthDispatch();
 	const [anchorEl, setAnchorEl] = useState<EventTarget & Element | null>(null);
 	const handleClick = (event : React.SyntheticEvent) => {
 		setAnchorEl(event.currentTarget);
@@ -61,14 +64,9 @@ const Member = ({ user } : MemberProps) => {
 	const handleClose = () => {
 		setAnchorEl(null);
 	};
-	const userToAdmin = () => {
-		axios.put(`http://localhost:8080/v1/works-in/${user.userID}`)
-			.then((res) => {
-				console.dir(res);
-			})
-			.catch((err) => {
-				console.dir(err);
-			});
+	const userAuthChange = (auth: number) => {
+		// 유저 권한 변경
+		setUserAuth(user.userID, auth);
 	};
 	const returnMenu = () => {
 		let menuString = '관리자 권한 부여';
@@ -92,7 +90,7 @@ const Member = ({ user } : MemberProps) => {
 				onClose={handleClose}
 				className="menu-popup"
 			>
-				<MenuItem onClick={userToAdmin}>
+				<MenuItem onClick={() => userAuthChange(user.AuthLvL)}>
 					<ListItemIcon>
 						<SupervisedUserCircleIcon />
 					</ListItemIcon>

--- a/frontend/src/components/Shared/Member.tsx
+++ b/frontend/src/components/Shared/Member.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 
-import { Grid, Tooltip, Avatar } from '@material-ui/core';
+import {
+	Tooltip, Avatar, Menu, MenuItem, ListItemIcon
+} from '@material-ui/core';
 import MoodIcon from '@material-ui/icons/Mood';
 import PetsIcon from '@material-ui/icons/Pets';
 import AppleIcon from '@material-ui/icons/Apple';
@@ -9,6 +11,8 @@ import AudiotrackIcon from '@material-ui/icons/Audiotrack';
 import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import CakeIcon from '@material-ui/icons/Cake';
 import ChildCareIcon from '@material-ui/icons/ChildCare';
+import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
+import CallMissedOutgoingIcon from '@material-ui/icons/CallMissedOutgoing';
 
 import { UserObj } from '../Model';
 
@@ -43,14 +47,50 @@ const returnIcon = (text : string) => {
 	return icon;
 };
 
-const Member = (user : UserObj) => {
-	const a = 1;
+type MemberProps = {
+	user: UserObj
+}
+
+const Member = ({ user } : MemberProps) => {
+	const [anchorEl, setAnchorEl] = useState<EventTarget & Element | null>(null);
+	const handleClick = (event : React.SyntheticEvent) => {
+		setAnchorEl(event.currentTarget);
+	};
+	const handleClose = () => {
+		setAnchorEl(null);
+	};
 	return (
-		<Tooltip placement="bottom" title={user.userName} arrow>
-			<Avatar className={clsx('member', user.userIcon)}>
-				{returnIcon(user.userIcon)}
-			</Avatar>
-		</Tooltip>
+		<>
+			<Tooltip placement="bottom" title={user.userName} arrow>
+				<Avatar className={clsx('member', user.userIcon)} onClick={handleClick}>
+					{returnIcon(user.userIcon)}
+				</Avatar>
+			</Tooltip>
+			<Menu
+				anchorEl={anchorEl}
+				keepMounted
+				anchorOrigin={{
+					vertical: 'bottom',
+					horizontal: 'center',
+				}}
+				open={anchorEl !== null}
+				onClose={handleClose}
+				className="menu-popup"
+			>
+				<MenuItem>
+					<ListItemIcon>
+						<SupervisedUserCircleIcon />
+						관리자 권한부여
+					</ListItemIcon>
+				</MenuItem>
+				<MenuItem>
+					<ListItemIcon>
+						<CallMissedOutgoingIcon />
+						추방하기
+					</ListItemIcon>
+				</MenuItem>
+			</Menu>
+		</>
 	);
 };
 

--- a/frontend/src/components/Shared/SideMenu.tsx
+++ b/frontend/src/components/Shared/SideMenu.tsx
@@ -42,8 +42,8 @@ const SideMenu = ({ open, setOpen, pid } : SideMenuProps) => {
 	return (
 		<>
 			{
-				// project network를 통해 안들어오거나, pid가 정해지지 않거나, pid에 해당하는 project가 없으면 표시하지 x
-				project && pid && project[pid] &&
+				// project network를 통해 안들어오거나, pid에 해당하는 project가 없으면 표시하지 x
+				project && project[pid] &&
 				<Grid className="detail">
 					<Grid className="private">
 						<Button

--- a/frontend/src/components/Shared/SideMenu.tsx
+++ b/frontend/src/components/Shared/SideMenu.tsx
@@ -9,7 +9,7 @@ import StarBorderIcon from '@material-ui/icons/StarBorder';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
-import { ProjectObj, useProjectState, useProjectDispatch } from '../Model';
+import { ProjectObj, useProjectState, useProjectUpdate } from '../Model';
 import { Button } from '.';
 
 type SideMenuProps = {
@@ -20,8 +20,7 @@ type SideMenuProps = {
 
 const SideMenu = ({ open, setOpen, pid } : SideMenuProps) => {
 	const project : ProjectObj | undefined = useProjectState();
-	const setProject : (id: number, p: ProjectObj) => void = useProjectDispatch();
-	const [update, forceUpdate] = useState(true);
+	const setProject : (id: number, p: ProjectObj) => void = useProjectUpdate();
 
 	const togglePrivate = () => {
 		if (project === undefined || pid === undefined) {
@@ -30,7 +29,6 @@ const SideMenu = ({ open, setOpen, pid } : SideMenuProps) => {
 		const tmp = project;
 		tmp[pid].isPrivate = !tmp[pid].isPrivate;
 		setProject(pid, tmp);
-		forceUpdate(!update);
 	};
 	const toggleMark = () => {
 		if (project === undefined || pid === undefined) {
@@ -39,13 +37,13 @@ const SideMenu = ({ open, setOpen, pid } : SideMenuProps) => {
 		const tmp = project;
 		tmp[pid].bookMark = !tmp[pid].bookMark;
 		setProject(pid, tmp);
-		forceUpdate(!update);
 	};
 
 	return (
 		<>
 			{
-				project && pid &&
+				// project network를 통해 안들어오거나, pid가 정해지지 않거나, pid에 해당하는 project가 없으면 표시하지 x
+				project && pid && project[pid] &&
 				<Grid className="detail">
 					<Grid className="private">
 						<Button

--- a/frontend/src/components/Shared/SubMenu.tsx
+++ b/frontend/src/components/Shared/SubMenu.tsx
@@ -10,7 +10,7 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 
 import { Window, WindowHeader, Button } from '.';
-import { useProjectState, ProjectObj } from '../Model';
+import { useProjectState, ProjectObj, useProjectDelete } from '../Model';
 
 type SubMenuProps = {
 	pid : number;
@@ -23,6 +23,7 @@ const SubMenu = ({ pid } : SubMenuProps) => {
 
 	const userAuth = 2;
 	const project : ProjectObj | undefined = useProjectState();
+	const deleteProject : (id : number) => void = useProjectDelete();
 	const windows =
 		<>
 			<Window
@@ -59,16 +60,6 @@ const SubMenu = ({ pid } : SubMenuProps) => {
 				/>
 			</Window>
 		</>;
-
-	const deleteProject = () => {
-		axios.delete(`http://localhost:8080/v1/project-api/project/${pid}`)
-			.then((res) => {
-				console.dir(res);
-			})
-			.catch((e) => {
-				console.dir(e);
-			});
-	};
 
 	const hangUpProject = () => {
 		/* api 미구현 */
@@ -115,7 +106,7 @@ const SubMenu = ({ pid } : SubMenuProps) => {
 									value={<DeleteIcon />}
 									onClickFun={() => {
 										if (window.confirm(`[${project[pid].name}] 프로젝트를 정말로 삭제하시겠습니까?`)) {
-											deleteProject();
+											deleteProject(pid);
 										}
 									}}
 								/>

--- a/frontend/src/components/Sub/ProjectHead.tsx
+++ b/frontend/src/components/Sub/ProjectHead.tsx
@@ -12,7 +12,7 @@ import {
 	Button, SubMenu, SideMenu, Member
 } from '../Shared';
 import {
-	ProjectObj, ProjectTeamObj, useUserState, useProjectState, usePIDState, useTeamState
+	ProjectObj, ProjectTeamObj, ProjectUserObj, useUserState, useProjectState, usePIDState, useTeamState
 } from '../Model';
 
 const buttonRef = createRef<HTMLDivElement>();
@@ -29,7 +29,7 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 	const project : ProjectObj | undefined = useProjectState();
 	const team : ProjectTeamObj | undefined = useTeamState();
 	const pid : number = usePIDState();
-	const userID : number = useUserState();
+	const nowUser : ProjectUserObj | undefined = useUserState();
 
 	const [open, setOpen] = useState(false);
 
@@ -68,7 +68,7 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 							</Grid>
 						</Grid>
 						{
-							team &&
+							team && nowUser &&
 							<Grid className="member-con">
 								<Grid className="all-member">
 									{
@@ -83,16 +83,7 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 									</Tooltip>
 								</Grid>
 								<Grid className="my-icon">
-									{
-										team.map((member) => {
-											if (member.userID === userID) {
-												return (
-													<Member user={member} />
-												);
-											}
-											return undefined;
-										})
-									}
+									<Member user={nowUser} />
 								</Grid>
 							</Grid>
 						}

--- a/frontend/src/components/Sub/ProjectHead.tsx
+++ b/frontend/src/components/Sub/ProjectHead.tsx
@@ -51,7 +51,8 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 						/>
 				}
 				{
-					project && pid &&
+					// project network를 통해 안들어오거나, pid가 정해지지 않거나, pid에 해당하는 project가 없으면 표시하지 x
+					project && pid && project[pid] &&
 					<>
 						<Grid className="info-con">
 							<Grid className="border-con">
@@ -71,7 +72,7 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 							<Grid className="member-con">
 								<Grid className="all-member">
 									{
-										team.map((member) => Member(member))
+										team.map((member) => <Member user={member} />)
 									}
 								</Grid>
 								<Grid className="plus-member">
@@ -86,7 +87,7 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 										team.map((member) => {
 											if (member.userID === userID) {
 												return (
-													Member(member)
+													<Member user={member} />
 												);
 											}
 											return undefined;

--- a/frontend/src/components/Sub/ProjectHead.tsx
+++ b/frontend/src/components/Sub/ProjectHead.tsx
@@ -51,8 +51,8 @@ const ProjectHead = forwardRef<HTMLDivElement, ProjectHeadProps>(({
 						/>
 				}
 				{
-					// project network를 통해 안들어오거나, pid가 정해지지 않거나, pid에 해당하는 project가 없으면 표시하지 x
-					project && pid && project[pid] &&
+					// project network를 통해 안들어오거나, pid에 해당하는 project가 없으면 표시하지 x
+					project && project[pid] &&
 					<>
 						<Grid className="info-con">
 							<Grid className="border-con">

--- a/frontend/src/components/Sub/SideProject.tsx
+++ b/frontend/src/components/Sub/SideProject.tsx
@@ -1,9 +1,9 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, Dispatch } from 'react';
 import clsx from 'clsx';
 
 import { Grid } from '@material-ui/core';
 
-import { useProjectState, ProjectObj } from '../Model';
+import { useProjectState, ProjectObj, usePIDDispatch } from '../Model';
 import { SubMenu, SideMenu } from '../Shared';
 
 type SideProjectProps = {
@@ -13,6 +13,7 @@ type SideProjectProps = {
 const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ pid }, ref) => {
 	const [open, setOpen] = useState(false);
 	const project : ProjectObj | undefined = useProjectState();
+	const setPID : Dispatch<number> = usePIDDispatch();
 
 	return (
 		<Grid ref={ref} className="side-project">
@@ -21,7 +22,7 @@ const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ pid }, ref) 
 				<Grid className="project-info">
 					<Grid className="info">
 						<Grid className={clsx('bg-color', project[pid].bgColor)}> </Grid>
-						<Grid className="project-name"><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
+						<Grid className="project-name" onClick={() => setPID(pid)}><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
 					</Grid>
 					<SideMenu
 						open={open}

--- a/frontend/src/components/Sub/SideProject.tsx
+++ b/frontend/src/components/Sub/SideProject.tsx
@@ -18,7 +18,7 @@ const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ project, pid
 		<Grid ref={ref} className={clsx('side-project', project[pid].bookMark && 'bookmark')}>
 			<Grid className="project-info">
 				<Grid className="info">
-					<Grid className={clsx('bg-color', project[pid].bgColor)}> </Grid>
+					<Grid className={clsx('bg-color', project[pid].bgColor)} />
 					<Grid className="project-name" onClick={() => setPID(pid)}><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
 				</Grid>
 				<SideMenu

--- a/frontend/src/components/Sub/SideProject.tsx
+++ b/frontend/src/components/Sub/SideProject.tsx
@@ -7,30 +7,26 @@ import { useProjectState, ProjectObj, usePIDDispatch } from '../Model';
 import { SubMenu, SideMenu } from '../Shared';
 
 type SideProjectProps = {
+	project: ProjectObj;
 	pid: number;
 }
 
-const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ pid }, ref) => {
+const SideProject = forwardRef<HTMLDivElement, SideProjectProps>(({ project, pid }, ref) => {
 	const [open, setOpen] = useState(false);
-	const project : ProjectObj | undefined = useProjectState();
 	const setPID : Dispatch<number> = usePIDDispatch();
-
 	return (
-		<Grid ref={ref} className="side-project">
-			{
-				project &&
-				<Grid className="project-info">
-					<Grid className="info">
-						<Grid className={clsx('bg-color', project[pid].bgColor)}> </Grid>
-						<Grid className="project-name" onClick={() => setPID(pid)}><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
-					</Grid>
-					<SideMenu
-						open={open}
-						setOpen={setOpen}
-						pid={pid}
-					/>
+		<Grid ref={ref} className={clsx('side-project', project[pid].bookMark && 'bookmark')}>
+			<Grid className="project-info">
+				<Grid className="info">
+					<Grid className={clsx('bg-color', project[pid].bgColor)}> </Grid>
+					<Grid className="project-name" onClick={() => setPID(pid)}><p>{project[pid].name.length > 14 ? `${project[pid].name.substr(0, 14)}...` : project[pid].name}</p></Grid>
 				</Grid>
-			}
+				<SideMenu
+					open={open}
+					setOpen={setOpen}
+					pid={pid}
+				/>
+			</Grid>
 			{ open && <SubMenu pid={pid} /> }
 		</Grid>
 	);

--- a/frontend/src/components/View/PageView.tsx
+++ b/frontend/src/components/View/PageView.tsx
@@ -26,7 +26,10 @@ const PageView = forwardRef<HTMLDivElement, PageViewProps>(({
 
 	/* ==============테스크 윈도우 열기 위한 임의의 값들============== */
 	const buttonName = '테스크 설정하기';
-	const task = tasks && tasks[Number(Object.keys(tasks)[0])][0];
+	let task;
+	if (tasks !== undefined && Object.keys(tasks).length !== 0) {
+		task = tasks[Number(Object.keys(tasks)[0])][0];
+	}
 	// 지금은 가장 처음 task를 받아오게 설정되어있음
 	const [openTask, setOpenTask] = useState(false);
 
@@ -53,12 +56,15 @@ const PageView = forwardRef<HTMLDivElement, PageViewProps>(({
 					/>
 				</>}
 			<List mainTitle="제목" /* for test only */ />
-			<TaskView				/* for test only */
-				open={openTask}
-				handleTaskWindowClose={handleTaskWindowClose}
-				task={task}
-				ref={taskRef}
-			/>
+			{
+				task &&
+				<TaskView				/* for test only */
+					open={openTask}
+					handleTaskWindowClose={handleTaskWindowClose}
+					task={task}
+					ref={taskRef}
+				/>
+			}
 		</Grid>
 	);
 });

--- a/frontend/src/components/View/SideBarView.tsx
+++ b/frontend/src/components/View/SideBarView.tsx
@@ -9,6 +9,7 @@ import LockOpenIcon from '@material-ui/icons/LockOpen';
 import { Button, Window, WindowHeader } from '../Shared';
 import { SideProject } from '../Sub';
 import { useProjectState, ProjectObj, useProjectAdd } from '../Model';
+import { checkIsStringEmpty } from '../../function/FunctionManager';
 
 const buttonRef = createRef<HTMLDivElement>();
 
@@ -28,6 +29,11 @@ const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
 	const [name, setName] = useState('');
 
 	const makeProject = () => {
+		if (checkIsStringEmpty(name)) {
+			// name이 없으면 생성 x
+			alert('프로젝트 이름을 입력해주세요.');
+			return;
+		}
 		addProject(name, pri);
 		setModalOpen(false);
 	};

--- a/frontend/src/components/View/SideBarView.tsx
+++ b/frontend/src/components/View/SideBarView.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, forwardRef, useState, useEffect } from 'react';
+import React, { createRef, forwardRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { Grid, Input } from '@material-ui/core';
@@ -31,10 +31,6 @@ const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
 		addProject(name, pri);
 		setModalOpen(false);
 	};
-
-	useEffect(() => {
-		set
-	}, [project]);
 
 	return (
 		<Grid ref={ref} className={clsx('sidebar', type)}>
@@ -92,7 +88,7 @@ const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
 			</header>
 			<Grid className="project-con">
 				{
-					project && Object.keys(project).map((id) => <SideProject key={id} pid={Number(id)} />)
+					project && Object.keys(project).map((id) => <SideProject project={project} key={id} pid={Number(id)} />)
 				}
 			</Grid>
 			<Grid className="generate-project">

--- a/frontend/src/components/View/SideBarView.tsx
+++ b/frontend/src/components/View/SideBarView.tsx
@@ -1,5 +1,4 @@
-import React, { createRef, forwardRef, useState } from 'react';
-import axios from 'axios';
+import React, { createRef, forwardRef, useState, useEffect } from 'react';
 import clsx from 'clsx';
 
 import { Grid, Input } from '@material-ui/core';
@@ -9,7 +8,7 @@ import LockOpenIcon from '@material-ui/icons/LockOpen';
 
 import { Button, Window, WindowHeader } from '../Shared';
 import { SideProject } from '../Sub';
-import { useProjectState, ProjectObj } from '../Model';
+import { useProjectState, ProjectObj, useProjectAdd } from '../Model';
 
 const buttonRef = createRef<HTMLDivElement>();
 
@@ -23,21 +22,19 @@ const SideBarView = forwardRef<HTMLDivElement, SideBarViewProps>(({
 	type, handleSideBarClose
 }, ref) => {
 	const project : ProjectObj | undefined = useProjectState();
+	const addProject : (name: string, pri: boolean) => void = useProjectAdd();
 	const [modalOpen, setModalOpen] = useState(false);
 	const [pri, setPrivate] = useState(true);
 	const [name, setName] = useState('');
 
 	const makeProject = () => {
-		axios.post('http://localhost:8080/v1/project-api/project', {
-			'Name': name
-		})
-			.then((res) => {
-				console.dir(res);
-			})
-			.catch((e) => {
-				console.dir(e);
-			});
+		addProject(name, pri);
+		setModalOpen(false);
 	};
+
+	useEffect(() => {
+		set
+	}, [project]);
 
 	return (
 		<Grid ref={ref} className={clsx('sidebar', type)}>

--- a/frontend/src/scss/components/_member.scss
+++ b/frontend/src/scss/components/_member.scss
@@ -32,8 +32,15 @@
 .menu-popup{
 	.MuiMenu-paper{
 		margin: 2rem 0 0 0rem;
-		.MuiSvgIcon-root{
-			margin-right: 7px;
+		.MuiListItem-root{
+			font-size: 14px;
+			.MuiListItemIcon-root{
+				margin-right: 7px;
+				min-width: auto;
+				.MuiSvgIcon-root{
+					font-size: 20px;
+				}
+			}
 		}
 	}
 }

--- a/frontend/src/scss/components/_member.scss
+++ b/frontend/src/scss/components/_member.scss
@@ -29,3 +29,11 @@
 		border: 3px solid white;
 	}
 }
+.menu-popup{
+	.MuiMenu-paper{
+		margin: 2rem 0 0 0rem;
+		.MuiSvgIcon-root{
+			margin-right: 7px;
+		}
+	}
+}

--- a/frontend/src/scss/components/_sidebar.scss
+++ b/frontend/src/scss/components/_sidebar.scss
@@ -78,9 +78,11 @@
 				}
 				.detail{
 					width: 20%;
+					min-width: 70px;
 				}
 				.arrow{
 					width: 15%;
+					min-width: 40px;
 				}
 			}
 		}

--- a/frontend/src/scss/components/_sidebar.scss
+++ b/frontend/src/scss/components/_sidebar.scss
@@ -48,6 +48,9 @@
 		.side-project{
 			display: flex;
 			flex-direction: column;
+			&.bookmark{
+				order: -1;
+			}
 			.project-info{
 				display: flex;
 				justify-content: space-between;

--- a/frontend/src/scss/components/_sidebar.scss
+++ b/frontend/src/scss/components/_sidebar.scss
@@ -63,6 +63,7 @@
 						font-size: $md-font;
 						flex-shrink: 1!important;
 						word-break: break-all;
+						cursor: pointer;
 					}
 					.bg-color{
 						margin-right: 10px;


### PR DESCRIPTION
* model에 api 없이 사용할 수 있는 test data를 이전 그대로 기재해두었습니다.
* project를 update / add / delete 하는 함수 context를 작성하였습니다.
> model.tsx가 가면 갈수록 복잡해져 가서 모듈화 시켜야할 듯 합니다.
* task가 없어도 error 안나게 처리해두었습니다.
* side project의 이름을 클릭하면, 해당 프로젝트를 띄우도록 설정하였습니다.
* 유저 아바타를 클릭하면 유저에 대한 메뉴가 나오도록 하였습니다
* 북마크 설정된 project가 상위로 노출되도록 처리하였습니다.
> css order 이용
* 현재 user의 권한에 따라 member.tsx에서 나타나는 menu가 바뀌도록 구현했습니다.
* authUser api를 backend 단에서 작성한 후에 연결했습니다.